### PR TITLE
Remove spurious requirement for psyco and add pynetworktables2js

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pynetworktables==2020.0.1
 tornado==5.1.1
-psyco==1.6
 winappdbg==1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pynetworktables==2020.0.1
 tornado==5.1.1
 winappdbg==1.5
+pynetworktables2js==2019.0.0


### PR DESCRIPTION
Based on comment from Declan that this was incorrect.